### PR TITLE
Webpack config: removing commas

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,15 +9,15 @@ const config = {
   resolve: {
     modules: [
       path.resolve('./src'),
-      path.resolve('./node_modules'),
-    ],
+      path.resolve('./node_modules')
+    ]
   },
   output: {
     path: path.resolve(__dirname, './lib'),
-    filename: 'app.bundle.js',
+    filename: 'app.bundle.js'
   },
   devServer: {
-    contentBase: path.resolve(__dirname, './'),
+    contentBase: path.resolve(__dirname, './')
   },
   devtool: isProduction ? '' : 'source-map',
   module: {
@@ -25,10 +25,10 @@ const config = {
       test: /\.(js)$/,
       exclude: /node_modules/,
       use: [{
-        loader: 'babel-loader',
-      }],
-    }],
-  },
+        loader: 'babel-loader'
+      }]
+    }]
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
Removing commas after every last element - webpack-dev-server did not deliver ./lib/app.bundle.js so there was only a black canvas in the browser visiting http://localhost:8080/ - started working for me after removing these commas.